### PR TITLE
fix: correct release-please manifest format to resolve version parsing error

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,10 +1,4 @@
 {
-  "packages": {
-    ".": {
-      "version": "0.0.3-alpha"
-    },
-    "dapp": {
-      "version": "0.0.2-alpha"
-    }
-  }
-} 
+  ".": "0.0.3-alpha",
+  "dapp": "0.0.2-alpha"
+}


### PR DESCRIPTION
## 🔧 Fix Release-Please Version Parsing Error

This PR fixes the  error that was occurring in the release-please workflow.

### 🐛 **Problem**
The  file was using an invalid format that caused release-please to fail when trying to parse version strings.

### ✅ **Solution**
Updated the manifest file to use the correct format:
- **Before**: Empty/invalid format
- **After**: 

### 🎯 **What This Fixes**
- Resolves  error
- Enables proper version parsing for release-please
- Allows automated releases to work correctly
- Maintains alpha version support for both SDK and DApp packages

### 📋 **Changes Made**
- Fixed  format to match release-please expectations
- Used simple key-value format instead of nested objects
- Maintained correct version numbers for both packages

This fix ensures that release-please can properly parse version strings and create automated releases without errors.