### PR TITLE
ci: update dapp changelog path in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -42,7 +42,7 @@
     },
     "dapp": {
       "release-type": "node",
-      "changelog-path": "dapp/CHANGELOG.md",
+      "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
       "prerelease": true,
       "versioning": "prerelease",


### PR DESCRIPTION
## Description

This PR updates the release-please configuration to fix the changelog path for the dapp component.

## Changes

- **File**: 
- **Change**: Updated  from  to  for the dapp component

## Problem

The current configuration was pointing to  which may not exist or may not be the correct location for the changelog file.

## Solution

Updated the changelog path to point to the root  file, which is the standard location for changelog files in this repository structure.

## Impact

This change ensures that:
- Release-please can properly generate and update changelog entries for the dapp component
- Changelog entries will be written to the correct location
- Release automation will work correctly for dapp releases

## Testing

- [ ] Verify that release-please can read/write to the updated changelog path
- [ ] Confirm that dapp releases generate proper changelog entries