### PR TITLE
ci: upgrade deployment dapp arbitrum sepolia testnet config with poco diamond proxy by upgrading iexec sdk to latest

### DIFF
--- a/deployment-dapp/package-lock.json
+++ b/deployment-dapp/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "iexec": "^8.16.1",
+        "iexec": "^8.17.1",
         "typescript": "^5.0.4",
         "yup": "^1.2.0"
       },
@@ -3017,9 +3017,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/iexec": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.16.1.tgz",
-      "integrity": "sha512-0Kxt5z2gpjcwRkGmfr3/ckOk1G3p6G4s4CQzjtgKo8v64giLneO/PcbQAkRLW7imCNegvQL6Bpw1oQCwELYHqw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.17.1.tgz",
+      "integrity": "sha512-S6TZM6gZVn2qAd5spz3LOAPehQrpRsbrX/MsPVzvNHdE94c3FKptQ5o6vGwMIoL3soTLkhJPax7VM5EmH07wZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ensdomains/ens-contracts": "^1.2.5",

--- a/deployment-dapp/package.json
+++ b/deployment-dapp/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "iexec": "^8.16.1",
+    "iexec": "^8.17.1",
     "typescript": "^5.0.4",
     "yup": "^1.2.0"
   },


### PR DESCRIPTION
upgrade deployment dapp arbitrum sepolia testnet config with poco diamond proxy by upgrading iexec sdk to latest